### PR TITLE
Fix size_t vs u64 mismatch

### DIFF
--- a/redasm/disassembler/listing/listingrenderer.cpp
+++ b/redasm/disassembler/listing/listingrenderer.cpp
@@ -19,7 +19,7 @@ void ListingRenderer::render(u64 start, u64 count, void *userdata)
 {
     auto lock = s_lock_safe_ptr(m_document);
     const ListingCursor* cur = lock->cursor();
-    u64 end = start + count, line = start;
+    size_t end = start + count, line = start;
 
     for(u64 i = 0; line < std::min(lock->size(), end); i++, line++)
     {
@@ -107,7 +107,8 @@ bool ListingRenderer::getRendererLine(size_t line, RendererLine &rl)
 
 bool ListingRenderer::getRendererLine(const document_s_lock &lock, size_t line, RendererLine& rl)
 {
-    const ListingItem* item = lock->itemAt(std::min(line, lock->lastLine()));
+    size_t lastLine = lock->lastLine();
+    const ListingItem* item = lock->itemAt(std::min(line, lastLine));
 
     if(!item)
         return false;

--- a/redasm/types/buffer/abstractbuffer.h
+++ b/redasm/types/buffer/abstractbuffer.h
@@ -32,10 +32,11 @@ class AbstractBuffer
 
 template<typename T, typename InBufferType, typename OutBufferType> void swapEndianness(const InBufferType* inbuffer, OutBufferType* outbuffer, size_t size = 0)
 {
-    if(!size)
-        size = inbuffer->size();
+    size_t inbufferSize = inbuffer->size();
+    if (!size)
+        size = inbufferSize;
 
-    size = std::min(size, inbuffer->size());
+    size = std::min(size, inbufferSize);
 
     if(outbuffer->size() < size)
         outbuffer->resize(size);

--- a/redasm/types/buffer/bufferview.cpp
+++ b/redasm/types/buffer/bufferview.cpp
@@ -10,7 +10,7 @@ const std::string BufferView::WILDCARD_BYTE = "??";
 BufferView::BufferView(): m_buffer(nullptr), m_offset(0), m_size(0) { }
 BufferView::BufferView(const AbstractBuffer *buffer, u64 offset, u64 size): m_buffer(buffer), m_offset(offset), m_size(size) { }
 
-BufferView BufferView::view(size_t offset, size_t size) const
+BufferView BufferView::view(u64 offset, u64 size) const
 {
     if(!size)
         size = m_size - offset;


### PR DESCRIPTION
While trying to build on macOS for https://github.com/REDasmOrg/REDasm/pull/17 I faced some issues related to some values of type `size_t` conflicting with values of type `u64` (and the opposite), similar to https://github.com/REDasmOrg/REDasm/issues/14.

Changes in this pull request allows me to build correctly, but I have to say that I'm not confident that I'm not creating more problems here. Better to review carefully before merging, I'm still quite a beginner with C++ 😅.