### PR TITLE
Add missing include for std::remove

### DIFF
--- a/rdcore/builtin/graph/layeredlayout.h
+++ b/rdcore/builtin/graph/layeredlayout.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <algorithm>
 #include <unordered_map>
 #include <deque>
 #include <rdapi/graph/layout.h>


### PR DESCRIPTION
std::remove is provided by `<algorithm>`, should be included explicitly, otherwise compilation fails on gcc 14.2.1 with libstdc++.